### PR TITLE
Added note about extending time for array jobs

### DIFF
--- a/docs/cheaha/shell_commands.md
+++ b/docs/cheaha/shell_commands.md
@@ -33,6 +33,7 @@ for job in 15202444 15202445 15202446; do
   scontrol show job $job | grep TimeLimit | awk '{print $2}'
 done
 ```
+**Note:** Job Arrays can't be incremented / decremented and must modified with absolute runtimes. For example, to extend a job with a `TimeLimit` of 1 day 2 hours by an additional day, you would use `TimeLimit=2-02:00:00`
 
 ## Fix User Directories and Slurm Account
 


### PR DESCRIPTION
Added a note about extending TimeLimit for array jobs to address the following `scontrol` message

scontrol: error: TimeLimit increment/decrement not supported for job arrays